### PR TITLE
Use exc_info in logging messages.

### DIFF
--- a/OMPython/__init__.py
+++ b/OMPython/__init__.py
@@ -315,7 +315,7 @@ class OMCSessionBase(with_metaclass(abc.ABCMeta, object)):
         try:
             return self.ask('getParameterNames', className)
         except KeyError as ex:
-            logger.warning('OMPython error: {0}'.format(ex))
+            logger.warning('OMPython error:', exc_info=True)
             # FIXME: OMC returns with a different structure for empty parameter set
             return []
 
@@ -341,7 +341,7 @@ class OMCSessionBase(with_metaclass(abc.ABCMeta, object)):
                 OMParser.result = {}
                 return answer[2:]
             except (TypeError, UnboundLocalError) as ex:
-                logger.warning('OMParser error: {0}'.format(ex))
+                logger.warning('OMParser error:', exc_info=True)
                 return result
 
     def getExtendsModifierNames(self, className, componentName):
@@ -359,7 +359,7 @@ class OMCSessionBase(with_metaclass(abc.ABCMeta, object)):
                 OMParser.result = {}
                 return answer[2:]
             except (TypeError, UnboundLocalError) as ex:
-                logger.warning('OMParser error: {0}'.format(ex))
+                logger.warning('OMParser error:', exc_info=True)
                 return result
 
     def getNthComponentModification(self, className, comp_id):


### PR DESCRIPTION
I meant to use `exc_info`  like this, but on second thought I'm not so sure if that's more elegant, as you get the full traceback in the log message, which may not be desired. I initially regarded it as a more elegant way to deal with exceptions having, or not having, a `.message` attribute.